### PR TITLE
Fix for Makefile & added Markdown to requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 install:
-	pip install -r requirements
+	pip install -r requirements.txt
 	npm install http-server purgecss@1.4.2 uglifycss
 
 css: website

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyyaml==5.3
 Jinja2==2.11.1
 python-frontmatter==0.5.0
 mistune==2.0.0a2
+Markdown==3.2.1


### PR DESCRIPTION
I noticed two bugs when trying to serve the site locally:

- The markdown requirement was not in the requirements.txt
- The Makefile command for install had no suffix `.txt` for the requirements.